### PR TITLE
feat : CI pipeline 수정

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,27 +13,37 @@ jobs:
     permissions:
       contents: read
       checks: write
-      pull-requests: write 
+      pull-requests: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: JDK 21을 설치합니다.
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'gradle'
+      - uses: actions/checkout@v4
 
-    - name: Gradle을 SetUp 합니다.
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
-      with:
-        cache-read-only: false
-        
-    - name: Gradle 명령 실행을 위한 권한을 부여합니다.
-      run: chmod +x gradlew
+      - name: JDK 21을 설치합니다.
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
 
-    - name: Gradle clean build를 수행합니다.
-      run: ./gradlew clean build
+      - name: Gradle을 SetUp 합니다.
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+        with:
+          cache-read-only: false
+
+      - name: Gradle 명령 실행을 위한 권한을 부여합니다.
+        run: chmod +x gradlew
+
+      - name: application-secret.yml 파일 생성
+        run: echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
+
+      - name: Gradle clean build를 수행합니다.
+        run: ./gradlew clean build
+
+      - name: 빌드 결과물(JAR) 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: application-jar
+          path: build/libs/*.jar
+          retention-days: 1
 
   build-and-push:
     name: Docker 이미지를 빌드하고 Push합니다.
@@ -42,50 +52,40 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: JDK 21 및 Gradle 캐시 설정
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-        cache: 'gradle'
+      - name: 빌드 결과물(JAR) 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: application-jar
+          path: build/libs/
 
-    - name: Gradle 명령 실행을 위한 권한 부여
-      run: chmod +x gradlew
+      - name: .env 파일 생성
+        run: echo "${{ secrets.DOTENV_FILE }}" > .env
 
-    - name: application-secret.yml 파일 생성
-      run: echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
+      - name: Docker Buildx를 설정합니다.
+        uses: docker/setup-buildx-action@v1
 
-    - name: .env 파일 생성
-      run: echo "${{ secrets.DOTENV_FILE }}" > .env
-
-    - name: Gradle build 실행
-      run: ./gradlew build -x
-        test
-
-    - name: Docker Buildx를 설정합니다.
-      uses: docker/setup-buildx-action@v1
-
-    - name: Docker Login을 수행합니다.
-      uses: docker/login-action@v3
-      with:
+      - name: Docker Login을 수행합니다.
+        uses: docker/login-action@v3
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Docker 이미지 빌드 및 Docker Hub Push
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        tags: |
-          ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }}
-          ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
+      - name: Docker 이미지 빌드 및 Docker Hub Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-    - name: 배포 완료 알림
-      run: |
-        echo "🚀 Docker 이미지가 성공적으로 배포되었습니다!"
-        echo "Branch: ${{ github.ref_name }}"
-        echo "Commit: ${{ github.sha }}"
-          
+      - name: 배포 완료 알림
+        run: |
+          echo "🚀 Docker 이미지가 성공적으로 배포되었습니다!"
+          echo "Branch: ${{ github.ref_name }}"
+          echo "Commit: ${{ github.sha }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,9 @@
-FROM eclipse-temurin:21-jdk-jammy AS builder
-
-WORKDIR /workspace
-
-COPY gradlew .
-COPY gradle gradle
-
-COPY build.gradle .
-COPY settings.gradle .
-COPY src src
-
-RUN chmod +x ./gradlew && ./gradlew build -x test
-
 FROM eclipse-temurin:21-jre-jammy
 
 WORKDIR /app
 
-COPY --from=builder /workspace/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "a  pp.jar"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk-jammy AS builder
+
+WORKDIR /workspace
+
+COPY gradlew .
+COPY gradle gradle
+
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+
+RUN chmod +x ./gradlew && ./gradlew build -x test
+
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+COPY --from=builder /workspace/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Gradle 캐시 충돌: setup-java와 setup-gradle이 동시에 캐시를 관리하려다 충돌이 나서 아예 캐시가 꺼졌습니다.
- 중복 빌드: 첫 번째 Job에서 빌드한 결과물(JAR)을 버리고, 두 번째 Job에서 다시 처음부터 빌드하고 있습니다.
- Docker 캐시 미사용: Docker 빌드 시 레이어 캐싱(gha)을 사용하지 않아 매번 처음부터 이미지를 만들고 있습니다.

## 📝 작업 내용

- CI 과정 중 빌드 및 테스트를 할 때 JAR 파일을 만든 것을 아티팩트로 저장하고, build-and-push 단계에서 또 다시 빌드를 하는 것이 아닌 앞의 Job에서 만든 JAR 아티팩트를 이용하여 Docker Image를 빌드하도록 하였습니다.

- 기존에는 setup-java에서도 gradle 캐시를 관리하려고 하였기에 충돌이 발생하여 cache가 비활성화 되는 문제가 있었습니다. 따라서 setup-java 부분에 cache : 'gradle'을 삭제하여 setup-gradle 액션에서 gradle 캐시를 관리하도록 하였습니다.

- 마지막으로 Dockerfile이 원격에서 작동되는 것을 감안하여 multi-stage-build 방식이 아닌, 기존에 만들어 두었던 아티팩트를 COPY해와서 이미지를 빌드하는 것으로 변경하였습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

